### PR TITLE
Full codebase: niri-activity-rs — code review base

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -462,8 +462,10 @@ pub fn watch(quiet: bool) -> Result<(), Error> {
                 accumulated_passive_ms = 0;
                 accumulated_idle_ms = 0;
                 last_flush = now_instant;
-                input_baseline_ms = input_stats.last_activity_ms();
-                session_start_mono_ms = now_ms;
+                // DO NOT reset input_baseline_ms or session_start_mono_ms here.
+                // The idle timer must keep measuring from the last real input,
+                // otherwise idle_duration_ms resets to ~0 and we immediately exit Away
+                // on the next loop iteration — causing a 30-min Away→Active cycle.
             }
 
             if current_state == ActivityState::Away && new_state != ActivityState::Away {
@@ -500,7 +502,7 @@ pub fn watch(quiet: bool) -> Result<(), Error> {
             }
             last_idle_check = now_instant;
 
-            if current_state != ActivityState::Away
+            if current_state != ActivityState::Away && current_state != ActivityState::Idle
                 && now_instant.duration_since(last_flush) >= FLUSH_INTERVAL
             {
                 if let Some(info) = focused_id.and_then(|id| windows.get(&id)) {


### PR DESCRIPTION
## Full Codebase for Code Review

This PR contains the **entire codebase** of niri-activity-rs from initial commit to current master. All commits and files visible for Codex and automated review tools.

### What this project is
A Wayland activity tracker for the niri compositor. Monitors window focus via niri IPC, keyboard/mouse input via evdev, and session state via logind D-Bus. Stores events in SQLite and provides CLI reporting, email reports, XLSX/CSV export, and a ratatui TUI dashboard.

### Source files (12 modules)
- `src/main.rs` — CLI entrypoint, clap subcommands
- `src/config.rs` — TOML config loading, app classification, schedule/holiday logic
- `src/watcher.rs` — Main event loop, state machine (Active→Passive→Idle→Away→Locked)
- `src/input.rs` — evdev input monitoring, jiggler detection, mouse idle tracking
- `src/logind.rs` — D-Bus lock/suspend detection via logind
- `src/db.rs` — SQLite schema, migrations, event insertion, reclassification
- `src/report.rs` — Query/aggregation logic, streaks, timelines, daily breakdowns, exports
- `src/email.rs` — SMTP email sending, HTML body generation, XLSX attachment
- `src/fmt.rs` — Duration/percentage/distance formatting, colored bars, table truncation
- `src/tui.rs` — Ratatui terminal UI dashboard
- `src/theme.rs` — TUI color theming
- `src/error.rs` — Error enum (thiserror)

### Code review findings (59 total from 4 Oracle agents)

| Severity | Count | Key Themes |
|----------|-------|------------|
| CRITICAL | 7 | Away-cycling bug (FIXED), SQL interpolation, HTML injection, insecure temp file, integer overflow |
| HIGH | 18 | reclassify_all perf, 7x flush duplication, N-query exports, boolean blindness, late config validation |
| MEDIUM | 22 | Render-loop allocs, double timestamp parsing, silent error swallowing, missing transactions, poor contrast |
| LOW | 18 | Dead code, unused params, rounding bugs, hardcoded holidays, minor style |

### Priority fixes needed
1. **CRIT** — `email.rs:35`: Temp XLSX in world-readable `/tmp` → use `tempfile` crate
2. **CRIT** — `email.rs:144`: HTML injection in email body → add `html_escape()`
3. **CRIT** — `report.rs`: SQL string interpolation → parameterize with `?1`/`?2`
4. **CRIT** — `watcher.rs`: `as i64` truncation on time values → `try_into().unwrap_or`
5. **HIGH** — `db.rs:180`: `reclassify_all` loads entire DB on every startup → config hash check
6. **HIGH** — `main.rs:82-214`: 12 time-range args duplicated 4x → `#[command(flatten)]`
7. **HIGH** — `watcher.rs:210-702`: Flush+reset copy-pasted 7 times → extract helper
8. **HIGH** — `report.rs:1883`: Export issues N queries (1/day) → move `prepare()` outside loop
9. **HIGH** — `config.rs:81`: Schedule times as String, validated late → parse at load
10. **HIGH** — `fmt.rs:57`: `fmt_distance` div-by-zero on `mouse_dpi=0.0` → guard clause

### Quick wins (< 1 hour each)
- `fmt.rs`: Guard negative durations, div-by-zero in `fmt_distance`
- `email.rs`: `html_escape()` for HTML body, `tempfile` crate for XLSX
- `report.rs:1883`: Move `conn.prepare()` outside day loop in exports
- `main.rs:181`: Make `ExportFormat` a clap `ValueEnum`
- `logind.rs:48`: Replace `assert!` with `Result` (prevents daemon crash)
- `report.rs:770`: Replace `Vec::find` with `HashMap` index in `group_apps`

### Short projects (2-4 hours each)
- Flatten `TimeRangeArgs` with `#[command(flatten)]` — eliminates 4x duplication
- Parse Schedule fields at config load time — catches errors early
- Config-hash `reclassify_all` — skip when config unchanged
- Wrap DB migrations in transactions
- Input thread shutdown flags for graceful daemon stop

### Medium projects (1-2 days)
- Extract `flush_session` helper in watcher.rs — prevents future flush bugs
- Parameterize all SQL queries with `?1`/`?2` params
- Merge report queries into single-pass processing
- Add niri IPC reconnection logic (daemon dies if compositor restarts)

### Architecture notes (long-term)
- Error enum is a string bag — `NiriError(String)` for 15+ failure modes; split into typed variants
- Holiday hardcoding expires 2027 — warn or compute algorithmically
- `filter_map(|r| r.ok())` everywhere — silently swallows DB errors
- Atomic ordering — `Relaxed` reads on ARM; use `Acquire`/`Release`
- TUI render-loop allocations — static strings rebuilt every 250ms frame

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initial import of niri-activity-rs: a Wayland activity tracker for the niri compositor. Adds touchpad support, new metrics, neutral-time exports, and tighter idle/Away handling.

- **New Features**
  - Count touchpad ABS events as activity.
  - Typing intensity (keys/min) per app.
  - Mouse travel distance with DPI-based conversion.
  - False-active detection (input_active_secs) with a fix-false-active CLI tool.
  - Top Applications grouped by (app_id, category) to split mixed-category apps.
  - ActivTrak-compatible CSV includes neutral time.

- **Bug Fixes**
  - Prevent Away→Active cycling by not resetting idle baselines when entering Away; skip periodic flush during Idle.

<sup>Written for commit d1716017d8e819174ae8ce88f2708838c7488b63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive activity tracking and monitoring system with persistent data storage.
  * Introduced terminal-based dashboard with visualizations, metrics, and reports.
  * Added configurable activity categorization (productive/unproductive/neutral) with title-based rules.
  * Added email reporting capabilities for weekly and monthly summaries.
  * Added data export functionality (CSV, XLSX, JSON formats).
  * Added system lock/suspend detection and monitoring.
  * Added jiggler detection to identify synthetic input.

* **Chores**
  * Dependency upgrades and package rename to niri-activity-rs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->